### PR TITLE
Cria gerenciador de estado do tema

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
   "eslintConfig": {
     "extends": "react-app"
   },
+  "files": ["src/@types/styled-components.d.ts"],
   "browserslist": {
     "production": [
       ">0.2%",

--- a/frontend/src/@types/index.d.ts
+++ b/frontend/src/@types/index.d.ts
@@ -1,0 +1,1 @@
+declare module '*.svg';

--- a/frontend/src/@types/styled-components.d.ts
+++ b/frontend/src/@types/styled-components.d.ts
@@ -1,0 +1,7 @@
+import taNaMesaTheme from '../styles/taNaMesaTheme';
+
+type ThemeInterface = typeof taNaMesaTheme;
+
+declare module 'styled-components' {
+  interface DefaultTheme extends ThemeInterface {}
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 
 import Routes from './routes/index';
 import GlobalStyle from './styles/global';
+import AppProvider from './hooks';
 
 const App: React.FC = () => {
   return (
     <>
-      <Routes />
+      <AppProvider>
+        <Routes />
+      </AppProvider>
+
       <GlobalStyle />
     </>
   );

--- a/frontend/src/hooks/index.tsx
+++ b/frontend/src/hooks/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { UserThemeProvider } from './theme';
+
+const AppProvider: React.FC = ({ children }) => {
+  return <UserThemeProvider>{children}</UserThemeProvider>;
+};
+
+export default AppProvider;

--- a/frontend/src/hooks/theme.tsx
+++ b/frontend/src/hooks/theme.tsx
@@ -24,12 +24,14 @@ interface IAppTheme {
 
   secondaryYellow: string;
   secondaryRed: string;
+  secondaryRed02: string;
   secondaryWine: string;
   secondaryGreen: string;
   secondaryLightGreen: string;
 
   black: string;
   white: string;
+  gray: string;
 }
 
 const UserThemeContext = createContext<IUserThemeContextData | null>(null);
@@ -40,7 +42,11 @@ export const UserThemeProvider: React.FC = ({ children }) => {
   useEffect(() => {
     const themeType = localStorage.getItem('@TaNaMesa:theme');
 
-    setTheme(themeType === 'default' ? taNaMesaTheme : taNaMesaDarkTheme);
+    if (themeType) {
+      setTheme(themeType === 'default' ? taNaMesaTheme : taNaMesaDarkTheme);
+    } else {
+      localStorage.setItem('@TaNaMesa:theme', 'default');
+    }
   }, []);
 
   const switchTheme = useCallback(() => {

--- a/frontend/src/hooks/theme.tsx
+++ b/frontend/src/hooks/theme.tsx
@@ -1,0 +1,69 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  useEffect,
+} from 'react';
+
+import { ThemeProvider } from 'styled-components';
+import taNaMesaTheme from '../styles/taNaMesaTheme';
+import taNaMesaDarkTheme from '../styles/taNaMesaDarkTheme';
+
+interface IUserThemeContextData {
+  theme: IAppTheme;
+  switchTheme: () => void;
+}
+
+interface IAppTheme {
+  type: string;
+  primary01: string;
+  primary02: string;
+  primary03: string;
+  primary04: string;
+
+  secondaryYellow: string;
+  secondaryRed: string;
+  secondaryWine: string;
+  secondaryGreen: string;
+  secondaryLightGreen: string;
+
+  black: string;
+  white: string;
+}
+
+const UserThemeContext = createContext<IUserThemeContextData | null>(null);
+
+export const UserThemeProvider: React.FC = ({ children }) => {
+  const [theme, setTheme] = useState(taNaMesaTheme);
+
+  useEffect(() => {
+    const themeType = localStorage.getItem('@TaNaMesa:theme');
+
+    setTheme(themeType === 'default' ? taNaMesaTheme : taNaMesaDarkTheme);
+  }, []);
+
+  const switchTheme = useCallback(() => {
+    localStorage.setItem(
+      '@TaNaMesa:theme',
+      theme.type === 'default' ? 'dark' : 'default',
+    );
+    setTheme(theme === taNaMesaTheme ? taNaMesaDarkTheme : taNaMesaTheme);
+  }, [theme]);
+
+  return (
+    <UserThemeContext.Provider value={{ theme, switchTheme }}>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </UserThemeContext.Provider>
+  );
+};
+
+export function useUserTheme(): IUserThemeContextData {
+  const context = useContext(UserThemeContext);
+
+  if (!context) {
+    throw new Error('useUserTheme must be used within an UserThemeProvider');
+  }
+
+  return context;
+}

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -1,10 +1,24 @@
 import React from 'react';
+import { useTheme } from 'styled-components';
+
+import { useUserTheme } from 'hooks/theme';
+
+import { Container } from './styles';
 
 const Home: React.FC = () => {
+  const { switchTheme } = useUserTheme();
+  const theme = useTheme();
+
   return (
-    <>
+    <Container>
       <h1>Tá na Mesa</h1>
-    </>
+
+      <button type="button" onClick={switchTheme}>
+        Trocar tema
+      </button>
+
+      <h4>{theme.type}</h4>
+    </Container>
   );
 };
 

--- a/frontend/src/pages/Home/styles.ts
+++ b/frontend/src/pages/Home/styles.ts
@@ -1,1 +1,34 @@
 import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  height: 100vh;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: ${props => props.theme.white};
+
+  h1 {
+    color: ${props => props.theme.black};
+    margin-bottom: 2rem;
+  }
+
+  button {
+    background-color: ${props => props.theme.primary03};
+    padding: 1rem;
+    border-radius: 10px;
+    color: ${props => props.theme.black};
+    font-weight: bold;
+    transition: 0.2s all;
+
+    &:hover {
+      box-shadow: 0 0 15px ${props => props.theme.primary03};
+      transform: scaleY(1.1) scaleX(1.1);
+    }
+  }
+
+  h4 {
+    color: ${props => props.theme.black};
+    margin-top: 2rem;
+  }
+`;

--- a/frontend/src/styles/taNaMesaDarkTheme.ts
+++ b/frontend/src/styles/taNaMesaDarkTheme.ts
@@ -7,10 +7,12 @@ export default {
 
   secondaryYellow: '#E7E400',
   secondaryRed: '#D62631',
+  secondaryRed02: '#EB4040',
   secondaryWine: '#9E1D25',
   secondaryGreen: '#2BB426',
   secondaryLightGreen: '#8AED87',
 
   black: '#FFFFFF',
   white: '#000000',
+  gray: '#C4C4C4'
 };

--- a/frontend/src/styles/taNaMesaDarkTheme.ts
+++ b/frontend/src/styles/taNaMesaDarkTheme.ts
@@ -1,0 +1,16 @@
+export default {
+  type: 'dark',
+  primary01: '#FF0000',
+  primary02: '#5E2129',
+  primary03: '#FFA500',
+  primary04: '#A45E4D40',
+
+  secondaryYellow: '#E7E400',
+  secondaryRed: '#D62631',
+  secondaryWine: '#9E1D25',
+  secondaryGreen: '#2BB426',
+  secondaryLightGreen: '#8AED87',
+
+  black: '#FFFFFF',
+  white: '#000000',
+};

--- a/frontend/src/styles/taNaMesaTheme.ts
+++ b/frontend/src/styles/taNaMesaTheme.ts
@@ -1,9 +1,9 @@
 export default {
   type: 'default',
   primary01: '#8E3031',
-  primary02: '#7E2726',
-  primary03: '#B96739',
-  primary04: '#A45E4D',
+  primary02: '#7F2726',
+  primary03: '#B96738',
+  primary04: '#A35E4E',
 
   secondaryYellow: '#E7E400',
   secondaryRed: '#D62631',

--- a/frontend/src/styles/taNaMesaTheme.ts
+++ b/frontend/src/styles/taNaMesaTheme.ts
@@ -1,0 +1,16 @@
+export default {
+  type: 'default',
+  primary01: '#8E3031',
+  primary02: '#7E2726',
+  primary03: '#B96739',
+  primary04: '#A45E4D',
+
+  secondaryYellow: '#E7E400',
+  secondaryRed: '#D62631',
+  secondaryWine: '#9E1D25',
+  secondaryGreen: '#2BB426',
+  secondaryLightGreen: '#8AED87',
+
+  black: '#000000',
+  white: '#FFFFFF',
+};

--- a/frontend/src/styles/taNaMesaTheme.ts
+++ b/frontend/src/styles/taNaMesaTheme.ts
@@ -7,10 +7,12 @@ export default {
 
   secondaryYellow: '#E7E400',
   secondaryRed: '#D62631',
+  secondaryRed02: '#EB4040',
   secondaryWine: '#9E1D25',
   secondaryGreen: '#2BB426',
   secondaryLightGreen: '#8AED87',
 
   black: '#000000',
   white: '#FFFFFF',
+  gray: '#C4C4C4',
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue 
Resolves #4
<!-- Link the pull request's respective issue -->

## Descrição
Cria gerenciador de estado do tema da aplicação.

## Screenshots (Se houver necessidade):
<!--- You may want to show a new page functionality, for example -->
<!--- If not appropriate, just delete this topic -->
- Tema padrão:
![Captura de tela de 2021-09-07 22-22-38](https://user-images.githubusercontent.com/49161615/132430676-8d5738f7-cefe-405e-834b-65166411893a.png)

- Tema escuro:
![Captura de tela de 2021-09-07 22-22-35](https://user-images.githubusercontent.com/49161615/132430702-bd448163-92c4-4e9c-8897-ff9bad911176.png)



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Meu código segue os padrões de estilo desse projeto.
- [ ] Minhas alterações necessitam de atualização na documentação.
- [ ] Eu atualizei a documentação de acordo com as mudanças feitas nesse PR.

## Como validar?
Rodar a aplicação e clicar no botão de troca de tema e vẽ se tudo ocorre corretamente. Abrir o localStorage e checar se está criadno o '@TaNaMesa:theme' com o valor 'default' ou 'dark'.
